### PR TITLE
🎥 Lecture create, select 개발

### DIFF
--- a/src/main/java/com/wanted/growthmate/GrowthmateApplication.java
+++ b/src/main/java/com/wanted/growthmate/GrowthmateApplication.java
@@ -2,7 +2,9 @@ package com.wanted.growthmate;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class GrowthmateApplication {
 

--- a/src/main/java/com/wanted/growthmate/common/entity/BaseEntity.java
+++ b/src/main/java/com/wanted/growthmate/common/entity/BaseEntity.java
@@ -1,0 +1,32 @@
+package com.wanted.growthmate.common.entity;
+
+import jakarta.persistence.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.util.Objects;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity extends BaseTimeEntity{
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    protected Long id;
+
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BaseEntity that = (BaseEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/wanted/growthmate/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/wanted/growthmate/common/entity/BaseTimeEntity.java
@@ -1,0 +1,33 @@
+package com.wanted.growthmate.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.hibernate.annotations.Comment;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+
+public abstract class BaseTimeEntity {
+    @Comment("생성 일시")
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    protected LocalDateTime createAt;
+    @Comment("수정 일시")
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    protected LocalDateTime updateAt;
+
+    public LocalDateTime getCreateAt() {
+        return createAt;
+    }
+
+    public LocalDateTime getUpdateAt() {
+        return updateAt;
+    }
+}

--- a/src/main/java/com/wanted/growthmate/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/wanted/growthmate/common/entity/BaseTimeEntity.java
@@ -12,7 +12,6 @@ import java.time.LocalDateTime;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-
 public abstract class BaseTimeEntity {
     @Comment("생성 일시")
     @CreatedDate

--- a/src/main/java/com/wanted/growthmate/learning/lecture/domain/dto/LectureCreateRequest.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/domain/dto/LectureCreateRequest.java
@@ -1,0 +1,48 @@
+package com.wanted.growthmate.learning.lecture.domain.dto;
+
+import com.wanted.growthmate.learning.lecture.domain.entity.Lecture;
+import jakarta.validation.constraints.*;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LectureCreateRequest {
+
+    @NotNull(message = "courseId는 필수 입력 값입니다.")
+    private Long courseId;
+
+    @NotNull(message = "sectionId는 필수 입력 값입니다.")
+    private Long sectionId;
+
+    @NotBlank(message = "강의 제목은 필수 입력 값입니다.")
+    private String title;
+
+    @NotNull(message = "duration은 필수 입력 값입니다.")
+    @PositiveOrZero(message = "duration은 0 이상이어야 합니다.")
+    private Long duration;
+
+    @NotNull(message = "order는 필수 입력 값입니다.")
+    @Positive(message = "order는 1 이상의 정수여야 합니다.")
+    private Integer order;
+
+    @NotNull(message = "mediaId는 필수 입력 값입니다.")
+    @Positive(message = "mediaId는 1 이상의 정수여야 합니다.")
+    private Long mediaId;
+
+    private boolean isVisible;
+
+    public Lecture toEntity() {
+        return Lecture.builder()
+                .courseId(courseId)
+                .sectionId(sectionId)
+                .title(title)
+                .duration(duration)
+                .mediaId(mediaId)
+                .displayOrder(order)
+                .isVisible(isVisible)
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/wanted/growthmate/learning/lecture/domain/dto/LectureResponse.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/domain/dto/LectureResponse.java
@@ -1,0 +1,32 @@
+package com.wanted.growthmate.learning.lecture.domain.dto;
+
+import com.wanted.growthmate.learning.lecture.domain.entity.Lecture;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LectureResponse {
+    private Long lectureId;
+    private Long courseId;
+    private Long sectionId;
+    private String title;
+    private Long duration;
+    private Integer order;
+    private Long mediaId;
+    private boolean isVisible;
+
+    public static LectureResponse from(Lecture lecture) {
+        return LectureResponse.builder()
+                .lectureId(lecture.getId())
+                .courseId(lecture.getCourseId())
+                .sectionId(lecture.getSectionId())
+                .title(lecture.getTitle())
+                .duration(lecture.getDuration())
+                .order(lecture.getDisplayOrder())
+                .mediaId(lecture.getMediaId())
+                .isVisible(lecture.isVisible())
+                .build();
+    }
+
+}

--- a/src/main/java/com/wanted/growthmate/learning/lecture/domain/dto/LectureSummaryResponse.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/domain/dto/LectureSummaryResponse.java
@@ -1,0 +1,28 @@
+package com.wanted.growthmate.learning.lecture.domain.dto;
+
+import com.wanted.growthmate.learning.lecture.domain.entity.Lecture;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class LectureSummaryResponse {
+    private Long lectureId;
+    private Long courseId;
+    private Long sectionId;
+    private String title;
+    private Long duration;
+    private Long mediaId;
+
+    public static LectureSummaryResponse from(Lecture lecture) {
+        return LectureSummaryResponse.builder()
+                .lectureId(lecture.getId())
+                .courseId(lecture.getCourseId())
+                .sectionId(lecture.getSectionId())
+                .title(lecture.getTitle())
+                .duration(lecture.getDuration())
+                .mediaId(lecture.getMediaId())
+                .build();
+    }
+
+}

--- a/src/main/java/com/wanted/growthmate/learning/lecture/domain/entity/Lecture.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/domain/entity/Lecture.java
@@ -1,0 +1,91 @@
+package com.wanted.growthmate.learning.lecture.domain.entity;
+
+import com.wanted.growthmate.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.hibernate.annotations.Comment;
+
+import java.util.Objects;
+
+@Entity
+@Table(name = "lecture")
+@Builder
+@AllArgsConstructor
+public class Lecture extends BaseEntity {
+
+//    @ManyToOne()
+    @Getter
+    @Column(name = "course_id")
+    @Comment("강좌 ID")
+    private Long courseId;
+
+//    @ManyToOne()
+    @Getter
+    @Column(name = "section_id")
+    @Comment("섹션 ID")
+    private Long sectionId;
+
+    @Getter
+    @Column(nullable = false)
+    @NotBlank(message = "강의 제목은 필수입니다.")
+    @Comment("강의 제목")
+    private String title;
+
+
+    @Getter
+    @Column(nullable = false)
+    @Comment("강의 설명")
+    private Long duration;
+
+//    @OneToMany()
+    @Getter
+    @Column(name = "media_id", nullable = false)
+    @Comment("강의 미디어 ID")
+    private Long mediaId;
+
+    @Getter
+    @Column(name = "display_order", nullable = false)
+    @Comment("강의 화면 노출 순서")
+    private int displayOrder;
+
+    @Column(name = "is_visible", nullable = false)
+    @Builder.Default
+    @Comment("강의 노출여부")
+    private boolean isVisible = true;
+
+    public Lecture() {
+    }
+
+    public Lecture(Long courseId, Long sectionId, String title, Long duration, Long mediaId, int order) {
+        this.courseId = courseId;
+        this.sectionId = sectionId;
+        this.title = title;
+        this.duration = duration;
+        this.mediaId = mediaId;
+        this.displayOrder = order;
+    }
+
+    public boolean isVisible() {
+        return isVisible;
+    }
+
+    @Override
+    public String toString() {
+        return "Lecture{" +
+                "id=" + id +
+                ", courseId=" + courseId +
+                ", sectionId=" + sectionId +
+                ", title='" + title + '\'' +
+                ", duration=" + duration +
+                ", mediaId=" + mediaId +
+                ", displayOrder=" + displayOrder +
+                ", isVisible=" + isVisible +
+                ", createAt=" + createAt +
+                ", updateAt=" + updateAt +
+                '}';
+    }
+
+}

--- a/src/main/java/com/wanted/growthmate/learning/lecture/exception/LectureNotFoundException.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/exception/LectureNotFoundException.java
@@ -1,0 +1,7 @@
+package com.wanted.growthmate.learning.lecture.exception;
+
+public class LectureNotFoundException extends RuntimeException  {
+    public LectureNotFoundException(Long lectureId) {
+        super(lectureId + " ID의 강의를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/com/wanted/growthmate/learning/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/repository/LectureRepository.java
@@ -1,0 +1,13 @@
+package com.wanted.growthmate.learning.lecture.repository;
+
+import com.wanted.growthmate.learning.lecture.domain.dto.LectureSummaryResponse;
+import com.wanted.growthmate.learning.lecture.domain.entity.Lecture;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface LectureRepository extends JpaRepository<Lecture, Long> {
+    List<Lecture> findByCourseId(Long courseId);
+    List<Lecture> findBySectionId(Long sectionId);
+    List<Lecture> findBySectionIdOrderByDisplayOrderAsc(Long sectionId);
+}

--- a/src/main/java/com/wanted/growthmate/learning/lecture/service/LectureService.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/service/LectureService.java
@@ -1,0 +1,48 @@
+package com.wanted.growthmate.learning.lecture.service;
+
+import com.wanted.growthmate.learning.lecture.domain.dto.LectureCreateRequest;
+import com.wanted.growthmate.learning.lecture.domain.entity.Lecture;
+import com.wanted.growthmate.learning.lecture.domain.dto.LectureResponse;
+import com.wanted.growthmate.learning.lecture.exception.LectureNotFoundException;
+import com.wanted.growthmate.learning.lecture.repository.LectureRepository;
+import com.wanted.growthmate.learning.lecture.domain.dto.LectureSummaryResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class LectureService implements LectureServiceImpl {
+    @Autowired
+    LectureRepository lectureRepository;
+
+    @Override
+    public LectureResponse save(LectureCreateRequest lectureCreateRequest) {
+        return LectureResponse.from(
+                lectureRepository.save(lectureCreateRequest.toEntity())
+        );
+    }
+
+    @Override
+    public List<LectureSummaryResponse> findByCourseId(Long courseId) {
+        return lectureRepository.findByCourseId(courseId).stream().map(lecture ->
+            LectureSummaryResponse.from(lecture)
+        ).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<LectureSummaryResponse> findBySectionId(Long sectionId) {
+        return lectureRepository.findBySectionIdOrderByDisplayOrderAsc(sectionId).stream().map(lecture ->
+                LectureSummaryResponse.from(lecture)
+        ).collect(Collectors.toList());
+    }
+
+    @Override
+    public LectureResponse findByLectureId(Long lectureId) {
+        Lecture lecture = lectureRepository.findById(lectureId)
+                .orElseThrow(() -> new LectureNotFoundException(lectureId));
+        return LectureResponse.from(lecture);
+    }
+
+}

--- a/src/main/java/com/wanted/growthmate/learning/lecture/service/LectureServiceImpl.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/service/LectureServiceImpl.java
@@ -1,0 +1,18 @@
+package com.wanted.growthmate.learning.lecture.service;
+
+import com.wanted.growthmate.learning.lecture.domain.dto.LectureCreateRequest;
+import com.wanted.growthmate.learning.lecture.domain.dto.LectureResponse;
+import com.wanted.growthmate.learning.lecture.domain.dto.LectureSummaryResponse;
+
+import java.util.List;
+
+public interface LectureServiceImpl {
+    LectureResponse save(LectureCreateRequest lectureCreateRequest) ;
+
+    List<LectureSummaryResponse> findByCourseId(Long courseId);
+
+    List<LectureSummaryResponse> findBySectionId(Long sectionId) ;
+
+    LectureResponse findByLectureId(Long lectureId);
+
+}

--- a/src/test/java/com/wanted/growthmate/learning/lecture/service/LectureServiceTest.java
+++ b/src/test/java/com/wanted/growthmate/learning/lecture/service/LectureServiceTest.java
@@ -1,0 +1,35 @@
+package com.wanted.growthmate.learning.lecture.service;
+
+import com.wanted.growthmate.learning.lecture.domain.dto.LectureCreateRequest;
+import com.wanted.growthmate.learning.lecture.domain.dto.LectureResponse;
+import com.wanted.growthmate.learning.lecture.domain.dto.LectureSummaryResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+@SpringBootTest
+class LectureServiceTest {
+
+    @Autowired
+    LectureServiceImpl lectureService;
+
+    @Test
+    void save() {
+//        Lecture result = lectureService.save();
+//        Assertions.assertTrue(result.isVisible());
+    }
+
+    @Test
+    void findBySectionId() {
+        LectureResponse result = lectureService.save(LectureCreateRequest.builder().sectionId(1L).title("제목1").mediaId(1l).courseId(1l).order(1).duration(1l).build());
+
+        Assertions.assertTrue(result.isVisible());
+
+        List<LectureSummaryResponse> result1 = lectureService.findBySectionId(1L);
+        Assertions.assertTrue(result1.size() == 0, "section 번허로 된게 없음");
+
+    }
+}


### PR DESCRIPTION
## 📘 작업 내용

### Lecture 도메인 구현
**엔티티**
- `Lecture`: 강의 기본 정보(제목, 재생시간, 순서, 노출여부) 관리
- `BaseEntity` 상속으로 공통 필드 자동 관리

**DTO**
- `LectureCreateRequest`: 강의 생성 요청 및 Bean Validation 검증
- `LectureResponse`: 강의 상세 정보 응답
- `LectureSummaryResponse`: 강의 목록 조회용 요약 응답

**Repository**
- 코스별/섹션별 조회 쿼리 메서드
- 섹션 내 강의 순서 정렬 (`OrderByDisplayOrderAsc`)

**Service & Exception**
- 강의 CRUD 비즈니스 로직
- `LectureNotFoundException`: 커스텀 예외 처리

**Test**
- `LectureServiceTest`: 기본 서비스 동작 검증

---

## 🎯 도입 이유

- LXP 프로젝트의 핵심 도메인인 강의(Lecture) 관리 기능 구축
- 강좌(Course) → 섹션(Section) → 강의(Lecture) 계층 구조의 최소 단위 구현
- 강의 순서 및 노출 여부를 통한 학습 콘텐츠 관리 체계 마련

---

## ⚙️ 주요 기능

**1. 강의 생성**
```java
LectureCreateRequest.builder()
    .courseId(1L)
    .sectionId(1L)
    .title("스프링 부트 기초")
    .duration(1800L)
    .order(1)
    .mediaId(100L)
    .build();
```
- Bean Validation 기반 입력값 검증
- 필수 필드 및 유효성 체크

**2. 조회 기능**
- `findBySectionId()`: 섹션별 강의 목록 (순서 정렬)
- `findByCourseId()`: 코스 전체 강의 조회
- `findByLectureId()`: 개별 강의 상세 (예외 처리 포함)

**3. 기술적 특징**
- DTO 변환: `toEntity()`, `from()` 정적 팩토리 메서드
- 응답 DTO 분리로 목록/상세 조회 최적화
- Spring Data JPA 메서드 네이밍 기반 쿼리 자동 생성

---

## ⚠️ 개선 예정

- [ ] Service 인터페이스/구현체 네이밍 컨벤션 수정
- [ ] 필드 주입 → 생성자 주입 리팩토링
- [ ] ID 참조 → `@ManyToOne` 연관관계 매핑 전환 검토
- [ ] 테스트 코드 보강
- [ ] REST API 컨트롤러 추가 (후속 PR)

---

## 📝 참고

- Course/Section 도메인 미구현으로 ID 기반 참조 우선 적용
- 미디어(Media) 엔티티 연동은 별도 모듈 구현 후 진행