### PR TITLE
🎥 Lecture 도메인 - 수정 및 삭제 기능 구현

### DIFF
--- a/src/main/java/com/wanted/growthmate/GrowthmateApplication.java
+++ b/src/main/java/com/wanted/growthmate/GrowthmateApplication.java
@@ -2,7 +2,9 @@ package com.wanted.growthmate;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class GrowthmateApplication {
 

--- a/src/main/java/com/wanted/growthmate/common/entity/BaseEntity.java
+++ b/src/main/java/com/wanted/growthmate/common/entity/BaseEntity.java
@@ -1,0 +1,32 @@
+package com.wanted.growthmate.common.entity;
+
+import jakarta.persistence.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.util.Objects;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity extends BaseTimeEntity{
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    protected Long id;
+
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BaseEntity that = (BaseEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/wanted/growthmate/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/wanted/growthmate/common/entity/BaseTimeEntity.java
@@ -1,0 +1,33 @@
+package com.wanted.growthmate.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.hibernate.annotations.Comment;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+
+public abstract class BaseTimeEntity {
+    @Comment("생성 일시")
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    protected LocalDateTime createAt;
+    @Comment("수정 일시")
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    protected LocalDateTime updateAt;
+
+    public LocalDateTime getCreateAt() {
+        return createAt;
+    }
+
+    public LocalDateTime getUpdateAt() {
+        return updateAt;
+    }
+}

--- a/src/main/java/com/wanted/growthmate/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/wanted/growthmate/common/entity/BaseTimeEntity.java
@@ -12,7 +12,6 @@ import java.time.LocalDateTime;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-
 public abstract class BaseTimeEntity {
     @Comment("생성 일시")
     @CreatedDate

--- a/src/main/java/com/wanted/growthmate/learning/lecture/controller/LectureController.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/controller/LectureController.java
@@ -1,0 +1,85 @@
+package com.wanted.growthmate.learning.lecture.controller;
+
+import com.wanted.growthmate.learning.lecture.domain.dto.*;
+import com.wanted.growthmate.learning.lecture.service.LectureService;
+import jakarta.validation.Valid;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/sections/{sectionId}/lectures")
+public class LectureController {
+
+    private final LectureService lectureService;
+
+    public LectureController(LectureService lectureService) {
+        this.lectureService = lectureService;
+    }
+
+    @GetMapping
+    public String list(@PathVariable Long sectionId, Model model) {
+        List<LectureSummaryResponse> lectures = lectureService.findBySectionId(sectionId);
+        model.addAttribute("lectures", lectures);
+        model.addAttribute("sectionId", sectionId);
+        return "lecture/list";
+    }
+
+    @GetMapping("/{lectureId}")
+    public String detail(@PathVariable Long sectionId, @PathVariable Long lectureId, Model model) {
+        LectureResponse lecture = lectureService.findByLectureId(lectureId);
+        model.addAttribute("lecture", lecture);
+        model.addAttribute("sectionId", sectionId);
+        return "lecture/detail";
+    }
+
+    @PostMapping
+    public String create(@PathVariable Long sectionId, @Valid @ModelAttribute LectureCreateRequest request, RedirectAttributes redirectAttributes) {
+        request = LectureCreateRequest.builder()
+                .courseId(request.getCourseId())
+                .sectionId(sectionId)
+                .title(request.getTitle())
+                .duration(request.getDuration())
+                .mediaId(request.getMediaId())
+                .order(request.getOrder())
+                .isVisible(request.isVisible())
+                .build();
+        lectureService.save(request);
+        redirectAttributes.addFlashAttribute("message", "강의가 생성되었습니다.");
+        return "redirect:/sections/" + sectionId + "/lectures";
+    }
+
+    @PostMapping("/{lectureId}/update")
+    public String update(@PathVariable Long sectionId, @PathVariable Long lectureId, 
+                        @Valid @ModelAttribute LectureUpdateRequest request, RedirectAttributes redirectAttributes) {
+        lectureService.updateInfo(lectureId, request);
+        redirectAttributes.addFlashAttribute("message", "강의가 수정되었습니다.");
+        return "redirect:/sections/" + sectionId + "/lectures";
+    }
+
+    @PostMapping("/{lectureId}/order")
+    public String updateOrder(@PathVariable Long sectionId, @PathVariable Long lectureId, 
+                             @Valid @ModelAttribute LectureOrderUpdateRequest request, RedirectAttributes redirectAttributes) {
+        lectureService.updateOrder(lectureId, request);
+        redirectAttributes.addFlashAttribute("message", "순서가 변경되었습니다.");
+        return "redirect:/sections/" + sectionId + "/lectures";
+    }
+
+    @PostMapping("/{lectureId}/delete")
+    public String delete(@PathVariable Long sectionId, @PathVariable Long lectureId, RedirectAttributes redirectAttributes) {
+        lectureService.delete(lectureId);
+        redirectAttributes.addFlashAttribute("message", "강의가 삭제되었습니다.");
+        return "redirect:/sections/" + sectionId + "/lectures";
+    }
+
+    @PostMapping("/{lectureId}/soft-delete")
+    public String softDelete(@PathVariable Long sectionId, @PathVariable Long lectureId, RedirectAttributes redirectAttributes) {
+        lectureService.softDelete(lectureId);
+        redirectAttributes.addFlashAttribute("message", "강의가 비활성화되었습니다.");
+        return "redirect:/sections/" + sectionId + "/lectures";
+    }
+}
+

--- a/src/main/java/com/wanted/growthmate/learning/lecture/domain/dto/LectureCreateRequest.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/domain/dto/LectureCreateRequest.java
@@ -30,7 +30,8 @@ public class LectureCreateRequest {
     @Positive(message = "mediaId는 1 이상의 정수여야 합니다.")
     private Long mediaId;
 
-    private boolean isVisible;
+    @Builder.Default
+    private boolean isVisible = true;
 
     public Lecture toEntity() {
         return Lecture.builder()

--- a/src/main/java/com/wanted/growthmate/learning/lecture/domain/dto/LectureCreateRequest.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/domain/dto/LectureCreateRequest.java
@@ -1,0 +1,48 @@
+package com.wanted.growthmate.learning.lecture.domain.dto;
+
+import com.wanted.growthmate.learning.lecture.domain.entity.Lecture;
+import jakarta.validation.constraints.*;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LectureCreateRequest {
+
+    @NotNull(message = "courseId는 필수 입력 값입니다.")
+    private Long courseId;
+
+    @NotNull(message = "sectionId는 필수 입력 값입니다.")
+    private Long sectionId;
+
+    @NotBlank(message = "강의 제목은 필수 입력 값입니다.")
+    private String title;
+
+    @NotNull(message = "duration은 필수 입력 값입니다.")
+    @PositiveOrZero(message = "duration은 0 이상이어야 합니다.")
+    private Long duration;
+
+    @NotNull(message = "order는 필수 입력 값입니다.")
+    @Positive(message = "order는 1 이상의 정수여야 합니다.")
+    private Integer order;
+
+    @NotNull(message = "mediaId는 필수 입력 값입니다.")
+    @Positive(message = "mediaId는 1 이상의 정수여야 합니다.")
+    private Long mediaId;
+
+    private boolean isVisible;
+
+    public Lecture toEntity() {
+        return Lecture.builder()
+                .courseId(courseId)
+                .sectionId(sectionId)
+                .title(title)
+                .duration(duration)
+                .mediaId(mediaId)
+                .displayOrder(order)
+                .isVisible(isVisible)
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/wanted/growthmate/learning/lecture/domain/dto/LectureOrderUpdateRequest.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/domain/dto/LectureOrderUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.wanted.growthmate.learning.lecture.domain.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LectureOrderUpdateRequest {
+    @NotNull(message = "order는 필수 입력 값입니다.")
+    @Positive(message = "order는 1 이상의 정수여야 합니다.")
+    private Integer newOrder;
+
+    @NotNull(message = "섹션 ID는 필수입니다.")
+    private Long sectionId;
+
+}

--- a/src/main/java/com/wanted/growthmate/learning/lecture/domain/dto/LectureResponse.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/domain/dto/LectureResponse.java
@@ -1,0 +1,32 @@
+package com.wanted.growthmate.learning.lecture.domain.dto;
+
+import com.wanted.growthmate.learning.lecture.domain.entity.Lecture;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LectureResponse {
+    private Long lectureId;
+    private Long courseId;
+    private Long sectionId;
+    private String title;
+    private Long duration;
+    private Integer order;
+    private Long mediaId;
+    private boolean isVisible;
+
+    public static LectureResponse from(Lecture lecture) {
+        return LectureResponse.builder()
+                .lectureId(lecture.getId())
+                .courseId(lecture.getCourseId())
+                .sectionId(lecture.getSectionId())
+                .title(lecture.getTitle())
+                .duration(lecture.getDuration())
+                .order(lecture.getDisplayOrder())
+                .mediaId(lecture.getMediaId())
+                .isVisible(lecture.isVisible())
+                .build();
+    }
+
+}

--- a/src/main/java/com/wanted/growthmate/learning/lecture/domain/dto/LectureSummaryResponse.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/domain/dto/LectureSummaryResponse.java
@@ -13,6 +13,12 @@ public class LectureSummaryResponse {
     private String title;
     private Long duration;
     private Long mediaId;
+    private Integer order;
+    private boolean isVisible;
+
+    public boolean isVisible() {
+        return isVisible;
+    }
 
     public static LectureSummaryResponse from(Lecture lecture) {
         return LectureSummaryResponse.builder()
@@ -22,6 +28,8 @@ public class LectureSummaryResponse {
                 .title(lecture.getTitle())
                 .duration(lecture.getDuration())
                 .mediaId(lecture.getMediaId())
+                .order(lecture.getDisplayOrder())
+                .isVisible(lecture.isVisible())
                 .build();
     }
 

--- a/src/main/java/com/wanted/growthmate/learning/lecture/domain/dto/LectureSummaryResponse.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/domain/dto/LectureSummaryResponse.java
@@ -1,0 +1,28 @@
+package com.wanted.growthmate.learning.lecture.domain.dto;
+
+import com.wanted.growthmate.learning.lecture.domain.entity.Lecture;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class LectureSummaryResponse {
+    private Long lectureId;
+    private Long courseId;
+    private Long sectionId;
+    private String title;
+    private Long duration;
+    private Long mediaId;
+
+    public static LectureSummaryResponse from(Lecture lecture) {
+        return LectureSummaryResponse.builder()
+                .lectureId(lecture.getId())
+                .courseId(lecture.getCourseId())
+                .sectionId(lecture.getSectionId())
+                .title(lecture.getTitle())
+                .duration(lecture.getDuration())
+                .mediaId(lecture.getMediaId())
+                .build();
+    }
+
+}

--- a/src/main/java/com/wanted/growthmate/learning/lecture/domain/dto/LectureUpdateRequest.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/domain/dto/LectureUpdateRequest.java
@@ -1,0 +1,30 @@
+package com.wanted.growthmate.learning.lecture.domain.dto;
+
+import com.wanted.growthmate.learning.lecture.domain.entity.Lecture;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LectureUpdateRequest {
+    @NotNull(message = "sectionId는 필수 입력 값입니다.")
+    private Long sectionId;
+
+    @NotBlank(message = "강의 제목은 필수 입력 값입니다.")
+    private String title;
+
+    @NotNull(message = "duration은 필수 입력 값입니다.")
+    @PositiveOrZero(message = "duration은 0 이상이어야 합니다.")
+    private Long duration;
+
+    @NotNull(message = "mediaId는 필수 입력 값입니다.")
+    @Positive(message = "mediaId는 1 이상의 정수여야 합니다.")
+    private Long mediaId;
+
+    private Boolean isVisible;
+
+}

--- a/src/main/java/com/wanted/growthmate/learning/lecture/domain/entity/Lecture.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/domain/entity/Lecture.java
@@ -1,0 +1,91 @@
+package com.wanted.growthmate.learning.lecture.domain.entity;
+
+import com.wanted.growthmate.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.hibernate.annotations.Comment;
+
+import java.util.Objects;
+
+@Entity
+@Table(name = "lecture")
+@Builder
+@AllArgsConstructor
+public class Lecture extends BaseEntity {
+
+//    @ManyToOne()
+    @Getter
+    @Column(name = "course_id")
+    @Comment("강좌 ID")
+    private Long courseId;
+
+//    @ManyToOne()
+    @Getter
+    @Column(name = "section_id")
+    @Comment("섹션 ID")
+    private Long sectionId;
+
+    @Getter
+    @Column(nullable = false)
+    @NotBlank(message = "강의 제목은 필수입니다.")
+    @Comment("강의 제목")
+    private String title;
+
+
+    @Getter
+    @Column(nullable = false)
+    @Comment("강의 설명")
+    private Long duration;
+
+//    @OneToMany()
+    @Getter
+    @Column(name = "media_id", nullable = false)
+    @Comment("강의 미디어 ID")
+    private Long mediaId;
+
+    @Getter
+    @Column(name = "display_order", nullable = false)
+    @Comment("강의 화면 노출 순서")
+    private int displayOrder;
+
+    @Column(name = "is_visible", nullable = false)
+    @Builder.Default
+    @Comment("강의 노출여부")
+    private boolean isVisible = true;
+
+    public Lecture() {
+    }
+
+    public Lecture(Long courseId, Long sectionId, String title, Long duration, Long mediaId, int order) {
+        this.courseId = courseId;
+        this.sectionId = sectionId;
+        this.title = title;
+        this.duration = duration;
+        this.mediaId = mediaId;
+        this.displayOrder = order;
+    }
+
+    public boolean isVisible() {
+        return isVisible;
+    }
+
+    @Override
+    public String toString() {
+        return "Lecture{" +
+                "id=" + id +
+                ", courseId=" + courseId +
+                ", sectionId=" + sectionId +
+                ", title='" + title + '\'' +
+                ", duration=" + duration +
+                ", mediaId=" + mediaId +
+                ", displayOrder=" + displayOrder +
+                ", isVisible=" + isVisible +
+                ", createAt=" + createAt +
+                ", updateAt=" + updateAt +
+                '}';
+    }
+
+}

--- a/src/main/java/com/wanted/growthmate/learning/lecture/domain/entity/Lecture.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/domain/entity/Lecture.java
@@ -1,20 +1,24 @@
 package com.wanted.growthmate.learning.lecture.domain.entity;
 
 import com.wanted.growthmate.common.entity.BaseEntity;
+import com.wanted.growthmate.common.entity.SoftDeleteBaseEntity;
+import com.wanted.growthmate.learning.lecture.domain.dto.LectureUpdateRequest;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.hibernate.annotations.Comment;
 
-import java.util.Objects;
 
 @Entity
 @Table(name = "lecture")
 @Builder
 @AllArgsConstructor
-public class Lecture extends BaseEntity {
+public class Lecture extends SoftDeleteBaseEntity {
 
 //    @ManyToOne()
     @Getter
@@ -37,7 +41,7 @@ public class Lecture extends BaseEntity {
 
     @Getter
     @Column(nullable = false)
-    @Comment("강의 설명")
+    @Comment("강의 길이")
     private Long duration;
 
 //    @OneToMany()
@@ -72,6 +76,15 @@ public class Lecture extends BaseEntity {
         return isVisible;
     }
 
+
+    public void setDisplayOrder(int displayOrder) {
+        this.displayOrder = displayOrder;
+    }
+
+    public void setVisible(boolean visible) {
+        isVisible = visible;
+    }
+
     @Override
     public String toString() {
         return "Lecture{" +
@@ -88,4 +101,13 @@ public class Lecture extends BaseEntity {
                 '}';
     }
 
+    public void updateInfo(LectureUpdateRequest lectureUpdateRequest) {
+        this.sectionId = lectureUpdateRequest.getSectionId();
+        this.title = lectureUpdateRequest.getTitle();
+        if (lectureUpdateRequest.getIsVisible() != null) {
+            this.isVisible = lectureUpdateRequest.getIsVisible();
+        }
+        this.duration = lectureUpdateRequest.getDuration();
+        this.mediaId = lectureUpdateRequest.getMediaId();
+    }
 }

--- a/src/main/java/com/wanted/growthmate/learning/lecture/exception/LectureNotFoundException.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/exception/LectureNotFoundException.java
@@ -1,0 +1,7 @@
+package com.wanted.growthmate.learning.lecture.exception;
+
+public class LectureNotFoundException extends RuntimeException  {
+    public LectureNotFoundException(Long lectureId) {
+        super(lectureId + " ID의 강의를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/com/wanted/growthmate/learning/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/repository/LectureRepository.java
@@ -1,0 +1,13 @@
+package com.wanted.growthmate.learning.lecture.repository;
+
+import com.wanted.growthmate.learning.lecture.domain.dto.LectureSummaryResponse;
+import com.wanted.growthmate.learning.lecture.domain.entity.Lecture;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface LectureRepository extends JpaRepository<Lecture, Long> {
+    List<Lecture> findByCourseId(Long courseId);
+    List<Lecture> findBySectionId(Long sectionId);
+    List<Lecture> findBySectionIdOrderByDisplayOrderAsc(Long sectionId);
+}

--- a/src/main/java/com/wanted/growthmate/learning/lecture/service/LectureService.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/service/LectureService.java
@@ -1,0 +1,48 @@
+package com.wanted.growthmate.learning.lecture.service;
+
+import com.wanted.growthmate.learning.lecture.domain.dto.LectureCreateRequest;
+import com.wanted.growthmate.learning.lecture.domain.entity.Lecture;
+import com.wanted.growthmate.learning.lecture.domain.dto.LectureResponse;
+import com.wanted.growthmate.learning.lecture.exception.LectureNotFoundException;
+import com.wanted.growthmate.learning.lecture.repository.LectureRepository;
+import com.wanted.growthmate.learning.lecture.domain.dto.LectureSummaryResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class LectureService implements LectureServiceImpl {
+    @Autowired
+    LectureRepository lectureRepository;
+
+    @Override
+    public LectureResponse save(LectureCreateRequest lectureCreateRequest) {
+        return LectureResponse.from(
+                lectureRepository.save(lectureCreateRequest.toEntity())
+        );
+    }
+
+    @Override
+    public List<LectureSummaryResponse> findByCourseId(Long courseId) {
+        return lectureRepository.findByCourseId(courseId).stream().map(lecture ->
+            LectureSummaryResponse.from(lecture)
+        ).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<LectureSummaryResponse> findBySectionId(Long sectionId) {
+        return lectureRepository.findBySectionIdOrderByDisplayOrderAsc(sectionId).stream().map(lecture ->
+                LectureSummaryResponse.from(lecture)
+        ).collect(Collectors.toList());
+    }
+
+    @Override
+    public LectureResponse findByLectureId(Long lectureId) {
+        Lecture lecture = lectureRepository.findById(lectureId)
+                .orElseThrow(() -> new LectureNotFoundException(lectureId));
+        return LectureResponse.from(lecture);
+    }
+
+}

--- a/src/main/java/com/wanted/growthmate/learning/lecture/service/LectureService.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/service/LectureService.java
@@ -1,8 +1,6 @@
 package com.wanted.growthmate.learning.lecture.service;
 
-import com.wanted.growthmate.learning.lecture.domain.dto.LectureCreateRequest;
-import com.wanted.growthmate.learning.lecture.domain.dto.LectureResponse;
-import com.wanted.growthmate.learning.lecture.domain.dto.LectureSummaryResponse;
+import com.wanted.growthmate.learning.lecture.domain.dto.*;
 
 import java.util.List;
 
@@ -14,5 +12,13 @@ public interface LectureService {
     List<LectureSummaryResponse> findBySectionId(Long sectionId) ;
 
     LectureResponse findByLectureId(Long lectureId);
+
+    LectureResponse updateInfo(Long lectureId, LectureUpdateRequest request);
+
+    LectureResponse updateOrder(Long lectureId, LectureOrderUpdateRequest request);
+
+    void delete(Long lectureId);
+
+    void softDelete(Long lectureId);
 
 }

--- a/src/main/java/com/wanted/growthmate/learning/lecture/service/LectureService.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/service/LectureService.java
@@ -1,48 +1,18 @@
 package com.wanted.growthmate.learning.lecture.service;
 
 import com.wanted.growthmate.learning.lecture.domain.dto.LectureCreateRequest;
-import com.wanted.growthmate.learning.lecture.domain.entity.Lecture;
 import com.wanted.growthmate.learning.lecture.domain.dto.LectureResponse;
-import com.wanted.growthmate.learning.lecture.exception.LectureNotFoundException;
-import com.wanted.growthmate.learning.lecture.repository.LectureRepository;
 import com.wanted.growthmate.learning.lecture.domain.dto.LectureSummaryResponse;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
-@Service
-public class LectureService implements LectureServiceImpl {
-    @Autowired
-    LectureRepository lectureRepository;
+public interface LectureService {
+    LectureResponse save(LectureCreateRequest lectureCreateRequest) ;
 
-    @Override
-    public LectureResponse save(LectureCreateRequest lectureCreateRequest) {
-        return LectureResponse.from(
-                lectureRepository.save(lectureCreateRequest.toEntity())
-        );
-    }
+    List<LectureSummaryResponse> findByCourseId(Long courseId);
 
-    @Override
-    public List<LectureSummaryResponse> findByCourseId(Long courseId) {
-        return lectureRepository.findByCourseId(courseId).stream().map(lecture ->
-            LectureSummaryResponse.from(lecture)
-        ).collect(Collectors.toList());
-    }
+    List<LectureSummaryResponse> findBySectionId(Long sectionId) ;
 
-    @Override
-    public List<LectureSummaryResponse> findBySectionId(Long sectionId) {
-        return lectureRepository.findBySectionIdOrderByDisplayOrderAsc(sectionId).stream().map(lecture ->
-                LectureSummaryResponse.from(lecture)
-        ).collect(Collectors.toList());
-    }
-
-    @Override
-    public LectureResponse findByLectureId(Long lectureId) {
-        Lecture lecture = lectureRepository.findById(lectureId)
-                .orElseThrow(() -> new LectureNotFoundException(lectureId));
-        return LectureResponse.from(lecture);
-    }
+    LectureResponse findByLectureId(Long lectureId);
 
 }

--- a/src/main/java/com/wanted/growthmate/learning/lecture/service/LectureServiceImpl.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/service/LectureServiceImpl.java
@@ -1,18 +1,48 @@
 package com.wanted.growthmate.learning.lecture.service;
 
 import com.wanted.growthmate.learning.lecture.domain.dto.LectureCreateRequest;
+import com.wanted.growthmate.learning.lecture.domain.entity.Lecture;
 import com.wanted.growthmate.learning.lecture.domain.dto.LectureResponse;
+import com.wanted.growthmate.learning.lecture.exception.LectureNotFoundException;
+import com.wanted.growthmate.learning.lecture.repository.LectureRepository;
 import com.wanted.growthmate.learning.lecture.domain.dto.LectureSummaryResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
-public interface LectureServiceImpl {
-    LectureResponse save(LectureCreateRequest lectureCreateRequest) ;
+@Service
+public class LectureServiceImpl implements LectureService {
+    @Autowired
+    LectureRepository lectureRepository;
 
-    List<LectureSummaryResponse> findByCourseId(Long courseId);
+    @Override
+    public LectureResponse save(LectureCreateRequest lectureCreateRequest) {
+        return LectureResponse.from(
+                lectureRepository.save(lectureCreateRequest.toEntity())
+        );
+    }
 
-    List<LectureSummaryResponse> findBySectionId(Long sectionId) ;
+    @Override
+    public List<LectureSummaryResponse> findByCourseId(Long courseId) {
+        return lectureRepository.findByCourseId(courseId).stream().map(lecture ->
+            LectureSummaryResponse.from(lecture)
+        ).collect(Collectors.toList());
+    }
 
-    LectureResponse findByLectureId(Long lectureId);
+    @Override
+    public List<LectureSummaryResponse> findBySectionId(Long sectionId) {
+        return lectureRepository.findBySectionIdOrderByDisplayOrderAsc(sectionId).stream().map(lecture ->
+                LectureSummaryResponse.from(lecture)
+        ).collect(Collectors.toList());
+    }
+
+    @Override
+    public LectureResponse findByLectureId(Long lectureId) {
+        Lecture lecture = lectureRepository.findById(lectureId)
+                .orElseThrow(() -> new LectureNotFoundException(lectureId));
+        return LectureResponse.from(lecture);
+    }
 
 }

--- a/src/main/java/com/wanted/growthmate/learning/lecture/service/LectureServiceImpl.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/service/LectureServiceImpl.java
@@ -1,21 +1,26 @@
 package com.wanted.growthmate.learning.lecture.service;
 
-import com.wanted.growthmate.learning.lecture.domain.dto.LectureCreateRequest;
+import com.wanted.growthmate.learning.lecture.domain.dto.*;
 import com.wanted.growthmate.learning.lecture.domain.entity.Lecture;
-import com.wanted.growthmate.learning.lecture.domain.dto.LectureResponse;
 import com.wanted.growthmate.learning.lecture.exception.LectureNotFoundException;
 import com.wanted.growthmate.learning.lecture.repository.LectureRepository;
-import com.wanted.growthmate.learning.lecture.domain.dto.LectureSummaryResponse;
+import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
 public class LectureServiceImpl implements LectureService {
-    @Autowired
-    LectureRepository lectureRepository;
+
+    private final LectureRepository lectureRepository;
+
+    public LectureServiceImpl(LectureRepository lectureRepository) {
+        this.lectureRepository = lectureRepository;
+    }
 
     @Override
     public LectureResponse save(LectureCreateRequest lectureCreateRequest) {
@@ -27,7 +32,7 @@ public class LectureServiceImpl implements LectureService {
     @Override
     public List<LectureSummaryResponse> findByCourseId(Long courseId) {
         return lectureRepository.findByCourseId(courseId).stream().map(lecture ->
-            LectureSummaryResponse.from(lecture)
+                LectureSummaryResponse.from(lecture)
         ).collect(Collectors.toList());
     }
 
@@ -43,6 +48,68 @@ public class LectureServiceImpl implements LectureService {
         Lecture lecture = lectureRepository.findById(lectureId)
                 .orElseThrow(() -> new LectureNotFoundException(lectureId));
         return LectureResponse.from(lecture);
+    }
+
+    @Override
+    @Transactional
+    public LectureResponse updateInfo(Long lectureId, LectureUpdateRequest lectureUpdateRequest) {
+        Lecture lecture = lectureRepository.findById(lectureId)
+                .orElseThrow(() -> new LectureNotFoundException(lectureId));
+
+        lecture.updateInfo(lectureUpdateRequest);
+
+        return LectureResponse.from(lecture);
+    }
+
+    @Override
+    @Transactional
+    public LectureResponse updateOrder(Long lectureId, LectureOrderUpdateRequest request) {
+        List<Lecture> lectureList = lectureRepository.findBySectionId(request.getSectionId()).stream()
+                .sorted(Comparator.comparing(Lecture::getDisplayOrder))
+                .toList();
+
+        Lecture beforeLecture = null;
+        Lecture afterLecture = null;
+
+        for (Lecture lecture : lectureList) {
+            if (Objects.equals(lecture.getId(), lectureId)) 
+                beforeLecture = lecture;
+            
+            if (Objects.equals(lecture.getDisplayOrder(), request.getNewOrder())) 
+                afterLecture = lecture;
+            
+            if (beforeLecture != null && afterLecture != null) 
+                break;
+        }
+
+        if (beforeLecture == null || afterLecture == null) {
+            throw new IllegalArgumentException("대상 강의 또는 교환 대상 강의를 찾을 수 없습니다.");
+        }
+
+        // 순서 교환
+        int order = beforeLecture.getDisplayOrder();
+        beforeLecture.setDisplayOrder(afterLecture.getDisplayOrder());
+        afterLecture.setDisplayOrder(order);
+
+        return LectureResponse.from(beforeLecture);
+
+    }
+
+    @Override
+    @Transactional
+    public void delete(Long lectureId) {
+        if (!lectureRepository.existsById(lectureId))
+            throw new LectureNotFoundException(lectureId);
+        
+        lectureRepository.deleteById(lectureId);
+    }
+
+    @Override
+    @Transactional
+    public void softDelete(Long lectureId) {
+        Lecture lecture = lectureRepository.findById(lectureId)
+                .orElseThrow(() -> new LectureNotFoundException(lectureId));
+        lecture.markDeleted();
     }
 
 }

--- a/src/main/java/com/wanted/growthmate/learning/lecture/service/LectureServiceImpl.java
+++ b/src/main/java/com/wanted/growthmate/learning/lecture/service/LectureServiceImpl.java
@@ -1,0 +1,18 @@
+package com.wanted.growthmate.learning.lecture.service;
+
+import com.wanted.growthmate.learning.lecture.domain.dto.LectureCreateRequest;
+import com.wanted.growthmate.learning.lecture.domain.dto.LectureResponse;
+import com.wanted.growthmate.learning.lecture.domain.dto.LectureSummaryResponse;
+
+import java.util.List;
+
+public interface LectureServiceImpl {
+    LectureResponse save(LectureCreateRequest lectureCreateRequest) ;
+
+    List<LectureSummaryResponse> findByCourseId(Long courseId);
+
+    List<LectureSummaryResponse> findBySectionId(Long sectionId) ;
+
+    LectureResponse findByLectureId(Long lectureId);
+
+}

--- a/src/test/java/com/wanted/growthmate/learning/lecture/service/LectureServiceImplTest.java
+++ b/src/test/java/com/wanted/growthmate/learning/lecture/service/LectureServiceImplTest.java
@@ -2,9 +2,13 @@ package com.wanted.growthmate.learning.lecture.service;
 
 import com.wanted.growthmate.learning.lecture.domain.dto.LectureCreateRequest;
 import com.wanted.growthmate.learning.lecture.domain.dto.LectureResponse;
+import com.wanted.growthmate.learning.lecture.domain.dto.LectureUpdateRequest;
+import com.wanted.growthmate.learning.lecture.domain.dto.LectureOrderUpdateRequest;
 import com.wanted.growthmate.learning.lecture.domain.dto.LectureSummaryResponse;
+import com.wanted.growthmate.learning.lecture.domain.entity.Lecture;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -18,8 +22,17 @@ class LectureServiceImplTest {
 
     @Test
     void save() {
-//        Lecture result = lectureService.save();
-//        Assertions.assertTrue(result.isVisible());
+        LectureResponse result = lectureService.save(
+                LectureCreateRequest.builder()
+                        .sectionId(1L)
+                        .title("테스트 강의")
+                        .mediaId(1L)
+                        .courseId(1L)
+                        .order(1)
+                        .duration(10L)
+                        .build()
+        );
+        Assertions.assertTrue(result.isVisible());
     }
 
     @Test
@@ -31,5 +44,67 @@ class LectureServiceImplTest {
         List<LectureSummaryResponse> result1 = lectureService.findBySectionId(1L);
         Assertions.assertTrue(result1.size() == 0, "section 번허로 된게 없음");
 
+    }
+
+    @Test
+    void updateInfo() {
+        // given: 하나 생성
+        LectureResponse created = lectureService.save(LectureCreateRequest.builder()
+                .sectionId(10L)
+                .title("원본 제목")
+                .mediaId(10L)
+                .courseId(10L)
+                .order(1)
+                .duration(100L)
+                .build());
+
+        // when: 정보 수정
+        LectureUpdateRequest request = LectureUpdateRequest.builder()
+                .sectionId(20L)
+                .title("수정된 제목")
+                .duration(200L)
+                .mediaId(20L)
+                .isVisible(false)
+                .build();
+        LectureResponse updated = lectureService.updateInfo(created.getLectureId(), request);
+
+        // then
+        Assertions.assertEquals(20L, updated.getSectionId());
+        Assertions.assertEquals("수정된 제목", updated.getTitle());
+        Assertions.assertEquals(200L, updated.getDuration());
+        Assertions.assertEquals(20L, updated.getMediaId());
+        Assertions.assertFalse(updated.isVisible());
+    }
+
+    @Test
+    void updateOrder() {
+        // given: 같은 섹션에 5개 생성 (order 1..5)
+        long sectionId = 99L;
+        LectureResponse l1 = lectureService.save(LectureCreateRequest.builder().sectionId(sectionId).title("L1").mediaId(1L).courseId(1L).order(1).duration(1L).build());
+        LectureResponse l2 = lectureService.save(LectureCreateRequest.builder().sectionId(sectionId).title("L2").mediaId(2L).courseId(1L).order(2).duration(1L).build());
+        LectureResponse l3 = lectureService.save(LectureCreateRequest.builder().sectionId(sectionId).title("L3").mediaId(3L).courseId(1L).order(3).duration(1L).build());
+        LectureResponse l4 = lectureService.save(LectureCreateRequest.builder().sectionId(sectionId).title("L4").mediaId(4L).courseId(1L).order(4).duration(1L).build());
+        LectureResponse l5 = lectureService.save(LectureCreateRequest.builder().sectionId(sectionId).title("L5").mediaId(5L).courseId(1L).order(5).duration(1L).build());
+
+        // when: 2번째( order=2 )와 5번째( order=5 ) 순서 교환
+        LectureOrderUpdateRequest swapWith5 = LectureOrderUpdateRequest.builder()
+                .sectionId(sectionId)
+                .newOrder(5) // 교환 대상의 displayOrder
+                .build();
+        lectureService.updateOrder(l2.getLectureId(), swapWith5);
+
+        // then: 각 항목의 displayOrder가 기대대로 바뀌었는지 확인
+        List<LectureSummaryResponse> summaries = lectureService.findBySectionId(sectionId);
+        Integer orderL1 = summaries.stream().filter(s -> s.getTitle().equals("L1")).findFirst().get().getOrder();
+        Integer orderL2 = summaries.stream().filter(s -> s.getTitle().equals("L2")).findFirst().get().getOrder();
+        Integer orderL3 = summaries.stream().filter(s -> s.getTitle().equals("L3")).findFirst().get().getOrder();
+        Integer orderL4 = summaries.stream().filter(s -> s.getTitle().equals("L4")).findFirst().get().getOrder();
+        Integer orderL5 = summaries.stream().filter(s -> s.getTitle().equals("L5")).findFirst().get().getOrder();
+
+        Assertions.assertEquals(1, orderL1);
+        Assertions.assertEquals(5, orderL2);
+        Assertions.assertEquals(3, orderL3);
+        Assertions.assertEquals(4, orderL4);
+        Assertions.assertEquals(2, orderL5);
     }
 }

--- a/src/test/java/com/wanted/growthmate/learning/lecture/service/LectureServiceImplTest.java
+++ b/src/test/java/com/wanted/growthmate/learning/lecture/service/LectureServiceImplTest.java
@@ -11,7 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.util.List;
 
 @SpringBootTest
-class LectureServiceTest {
+class LectureServiceImplTest {
 
     @Autowired
     LectureServiceImpl lectureService;

--- a/src/test/java/com/wanted/growthmate/learning/lecture/service/LectureServiceTest.java
+++ b/src/test/java/com/wanted/growthmate/learning/lecture/service/LectureServiceTest.java
@@ -1,0 +1,35 @@
+package com.wanted.growthmate.learning.lecture.service;
+
+import com.wanted.growthmate.learning.lecture.domain.dto.LectureCreateRequest;
+import com.wanted.growthmate.learning.lecture.domain.dto.LectureResponse;
+import com.wanted.growthmate.learning.lecture.domain.dto.LectureSummaryResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+@SpringBootTest
+class LectureServiceTest {
+
+    @Autowired
+    LectureServiceImpl lectureService;
+
+    @Test
+    void save() {
+//        Lecture result = lectureService.save();
+//        Assertions.assertTrue(result.isVisible());
+    }
+
+    @Test
+    void findBySectionId() {
+        LectureResponse result = lectureService.save(LectureCreateRequest.builder().sectionId(1L).title("제목1").mediaId(1l).courseId(1l).order(1).duration(1l).build());
+
+        Assertions.assertTrue(result.isVisible());
+
+        List<LectureSummaryResponse> result1 = lectureService.findBySectionId(1L);
+        Assertions.assertTrue(result1.size() == 0, "section 번허로 된게 없음");
+
+    }
+}


### PR DESCRIPTION
📘 작업 내용

Service 메서드 구현:
  🔧 updateInfo(): 강의 정보 수정
    • 제목, 재생시간, 미디어ID, 섹션ID, 노출여부 수정 가능
    • @Transactional 적용으로 변경감지(Dirty Checking) 활용
  
  🔄 updateOrder(): 강의 순서 변경
    • 섹션 내에서 두 강의의 displayOrder 교환
    • 변경 대상 강의와 교환 대상 강의를 찾아 순서 스왑
  
  🗑️ delete(): 물리 삭제
    • DB에서 강의 데이터 완전 제거
    • 존재 여부 확인 후 LectureNotFoundException 예외 처리
  
  ♻️ softDelete(): 논리 삭제
    • markDeleted() 메서드 호출로 삭제 표시
    • 데이터는 유지하되 삭제된 것으로 처리

Test 추가:
  ✅ updateInfo() 테스트: 강의 정보 수정 검증
  ✅ updateOrder() 테스트: 순서 교환 로직 검증


🎯 도입 이유
  • 강의 콘텐츠의 수정 및 관리 기능 필요
  • 섹션 내 강의 순서 재배치 기능으로 학습 흐름 관리
  • 물리 삭제와 논리 삭제 두 가지 옵션 제공으로 유연한 데이터 관리


⚙️ 주요 기능

1️⃣ 강의 정보 수정
   • 강의 제목, 재생시간, 미디어ID, 섹션 이동, 노출여부 변경 가능
   • 트랜잭션 내에서 엔티티 변경감지 활용

2️⃣ 강의 순서 변경
   • 섹션 내 강의 순서 교환 (예: 2번과 5번 순서 스왑)
   • 정렬된 강의 목록에서 대상 찾아 순서 교환

3️⃣ 삭제 기능
   • 물리 삭제: DB에서 완전히 제거
   • 논리 삭제: SoftDeleteBaseEntity의 markDeleted() 호출


⚠️ 개선 예정
  • 순서 변경 로직 개선 (일괄 재정렬 기능 추가 검토)
  • 논리 삭제된 강의 복구 기능 추가
  • 예외 케이스 테스트 보강


📝 참고 사항
  • updateOrder() 메서드는 같은 섹션 내 두 강의의 순서만 교환
  • 논리 삭제는 SoftDeleteBaseEntity의 기능 활용